### PR TITLE
Assembler Fixes and Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-
+test.s

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const { localLabel } = require('./src/assembler/ParseNode')
-const { assemble, toHexString } = require('./src/assembler')
+const { assemble, toHexString, Instruction } = require('./src/assembler')
 const { parse } = require('./src/assembler/parser')
 
 /**
@@ -41,11 +41,10 @@ class Assembler {
     const root = parse(source)
     assemble(root).forEach(lir => {
       const address = toHexString(lir.address)
-      if (!lir.bytes) {
-        console.log(address, (lir.local ? '@' : '') + lir.name + ':')
+      if (lir instanceof Instruction) {
+        console.log(address, lir.hex, '\t', lir.source)
       } else {
-        let byteString = lir.toByteString()
-        console.log(address, byteString, '\t', lir.source)
+        console.log(address, (lir.local ? '@' : '') + lir.name + ':')
       }
     })
   }

--- a/src/assembler/index.js
+++ b/src/assembler/index.js
@@ -32,48 +32,219 @@ class Scope {
   }
 }
 
+/**
+ * Linear intermediate representation of a command.
+ */
 class Command {
-  constructor (name, params) {
-    this.name = name
-    this.params = params
+  /**
+   * Creates a new command representation.
+   * @param {object} opts Options for the command.
+   * @param {object} opts.line Source line information for the command.
+   * @param {string} opts.name The name of the command.
+   * @param {Array<ParseNode>} opts.params The parameters to the command.
+   */
+  constructor ({ line, name, params }) {
+    this._line = line
+    this._name = name
+    this._params = params
+  }
+
+  /**
+   * @return {object} Line information for the command.
+   */
+  get line () {
+    return this._line
+  }
+
+  /**
+   * @return {string} The name of the command.
+   */
+  get name () {
+    return this._name
+  }
+
+  /**
+   * @return {Array<ParseNode>} The paramters for the command.
+   */
+  get params () {
+    return this._params
   }
 }
 
+/**
+ * Linear intermediate representation of an instruction.
+ */
 class Instruction {
   constructor ({
-    addressingMode,
     info,
     localLabel,
-    name,
     value,
-    source,
+    line
   }) {
+    this._info = info
+    this._line = line
+
     this.address = -1
-    this.addressingMode = addressingMode
     this.bytes = []
-    this.length = info.length
-    this.localLabel = localLabel
-    this.name = name
-    this.opcode = info.opcode
-    this.source = source
     this.value = value
+
+    this.localLabel = localLabel
+
   }
 
-  toByteString () {
-    return this.bytes.map(b => {
+  /**
+   * @return {number} The address for the instruction.
+   */
+  get address () {
+    return this._address
+  }
+
+  /**
+   * Sets the program address for the instruction.
+   * @param {number} addr The address to set.
+   */
+  set address (addr) {
+    this._address = addr
+  }
+
+  /**
+   * @return {string} The addressing mode for the instruction.
+   */
+  get addressingMode () {
+    return this.info.addressingMode
+  }
+
+  /**
+   * @return {Uint8Array} The bytes for the instruction.
+   */
+  get bytes () {
+    return this._bytes
+  }
+
+  /**
+   * Sets the bytes for the instruction.
+   * @param {Uint8Array} bytes The bytes to set.
+   */
+  set bytes (bytes) {
+    this._bytes = bytes
+  }
+
+  /**
+   * @return {string} The hexadecimal string representation of the node's bytes.
+   */
+  get hex () {
+    const byteToHex = b => {
       const s = b.toString(16)
       return s.length < 2 ? '0' + s : s
-    }).join('').toUpperCase()
+    }
+    return this.bytes.map(byteToHex).join('').toUpperCase()
   }
-}
 
-class Label {
-  constructor (name, local = false) {
-    this.name = name
-    this.local = local
-    this.address = -1
+  /**
+   * @return {InstructionInfo} The general 6502 information for the instruction.
+   */
+  get info () {
+    return this._info
+  }
+
+  /**
+   * @return {number} The length of the instruction, in bytes.
+   */
+  get length () {
+    return this.info.length
+  }
+
+  /**
+   * @return {ParseLine} The line from which the instruction originated.
+   */
+  get line () {
+    return this._line
+  }
+
+  /**
+   * @return {string} The name of the instruction.
+   */
+  get name () {
+    return this.info.name
+  }
+
+  /**
+   * @return {number} The opcode for the instruction.
+   */
+  get opcode () {
+    return this.info.opcode
+  }
+
+  /**
+   * @return {string} The original assembly source for the instruction.
+   */
+  get source () {
+    return this.line.assembly
+  }
+
+  /**
+   * @return {ParseNode} The value for the node.
+   */
+  get value () {
+    return this._value
+  }
+
+  set value (val) {
+    this._value = val
   }
 }
+module.exports.Instruction = Instruction
+
+/**
+ * Linear intermediate representation of a label.
+ */
+class Label {
+  /**
+   * Creates a new linear intermediate label representation.
+   * @param {object} opts
+   * @param {string} opts.name The name for the label.
+   * @param {boolean} opts.local `true` if the label is local, `false`
+   *   otherwise.
+   */
+  constructor ({
+    name,
+    local
+  }) {
+    this.address = -1
+    this._local = local
+    this._name = name
+  }
+
+  /**
+   * @return {number} The instruction address for the label.
+   */
+  get address () {
+    return this._address
+  }
+
+  /**
+   * Sets the instruction address for the label.
+   * @param {number} addr The address to set.
+   */
+  set address (addr) {
+    this._address = addr
+  }
+
+  /**
+   * @return {boolean} `true` if this is a local label, `false` otherwise.
+   */
+  get local () {
+    return this._local
+  }
+
+  /**
+   * @return {string} The name of the label.
+   */
+  get name () {
+    return this._name
+  }
+}
+module.exports.Label = Label
 
 /**
  * A collection of recursive handlers for converting parse nodes into linear
@@ -100,18 +271,20 @@ class ParseNodeHandler {
   }
 
   static command (node, scope) {
+    const { line } = node
+    const { name } = node.data
     const params = node.children.map(child => assembleParseNode(child, scope))
-    return new Command(node.data.name, params)
+    return new Command({ line, name, params })
   }
 
   static label (node, scope) {
     const { name } = node.data
-    return new Label(name, false)
+    return new Label({ name, local: false })
   }
 
   static localLabel (node, scope) {
     const { name } = node.data
-    return new Label(name, true)
+    return new Label({ name, local: true })
   }
 
   static instruction (node, scope) {
@@ -204,14 +377,9 @@ class ParseNodeHandler {
     }
 
     try {
-      return new Instruction({
-        addressingMode,
-        info: InstructionInfo.get(name, addressingMode),
-        localLabel,
-        name,
-        source: node.line.assembly,
-        value,
-      })
+      const info = InstructionInfo.get(name, addressingMode)
+      const { line } = node
+      return new Instruction({ info, localLabel, line, value, })
     } catch (err) {
       throw new AssemblyError(err.message, node.line)
     }
@@ -252,7 +420,7 @@ function assembleParseNode (node, scope) {
   }
   const handler = ParseNodeHandler[node.type]
   if (!handler) {
-    throw new Error(`Encountered unknown ParseNode type '${node.type}'.`)
+    throw new AssemblyError(`Unknown parse node type "${node.type}"`, node.line)
   }
   return handler(node, scope)
 }
@@ -263,10 +431,13 @@ function assignAddresses (linearForm) {
   for (const lir of linearForm) {
     if (lir instanceof Command) {
       if (lir.name !== 'org') {
-        throw new Error(`Unknown command .${lir.name}`)
+        throw new AssemblyError(`Unknown command ".${lir.name}"`, lir.line)
       }
       if (lir.params.length !== 1 || !lir.params[0].isNumber()) {
-        throw new Error(`.org expects a single numeric command`)
+        throw new AssemblyError(
+          `.org expects a single numeric command`,
+          lir.line
+        )
       }
       address = lir.params[0].data.value
     } else if (lir instanceof Label) {
@@ -323,7 +494,6 @@ function buildInstruction (instruction) {
   }
 
   if (!value) {
-    console.log(instruction)
     throw new AssemblyError(
       'Internal error: expected instruction to have value',
       instruction.line

--- a/src/assembler/index.test.js
+++ b/src/assembler/index.test.js
@@ -1,0 +1,44 @@
+const { test, expect } = require('@jest/globals')
+const { assemble, Label, Instruction } = require('./index')
+const { parse } = require('./parser')
+
+test('assemble(): basic assembly and LIR output', () => {
+  const parseNode = parse(`
+    .org $1000
+    my_routine:
+    ldx #10
+    @loop: dex
+    bne @loop
+  `)
+
+  const lir = assemble(parseNode)
+  expect(lir).toBeInstanceOf(Array)
+  expect(lir.length).toEqual(5)
+
+  const [label, ldx, localLabel, dex, bne] = lir
+  let address = parseInt('1000', 16)
+
+  expect(label).toBeInstanceOf(Label)
+  expect(label.name).toEqual('my_routine')
+  expect(label.local).toBe(false)
+  expect(label.address).toEqual(address)
+
+  expect(ldx).toBeInstanceOf(Instruction)
+  expect(ldx.name).toEqual('ldx')
+  expect(ldx.address).toEqual(address)
+  address += ldx.length
+
+  expect(localLabel).toBeInstanceOf(Label)
+  expect(localLabel.name).toEqual('loop')
+  expect(localLabel.local).toBe(true)
+  expect(localLabel.address).toEqual(address)
+
+  expect(dex).toBeInstanceOf(Instruction)
+  expect(dex.name).toEqual('dex')
+  expect(dex.address).toEqual(address)
+  address += dex.length
+
+  expect(bne).toBeInstanceOf(Instruction)
+  expect(bne.name).toEqual('bne')
+  expect(bne.address).toEqual(address)
+})

--- a/src/assembler/instructions.js
+++ b/src/assembler/instructions.js
@@ -97,18 +97,28 @@ class InstructionInfo {
     if (!modes[addressingMode]) {
       throw new InvalidAddressingModeError(name, addressingMode)
     }
-    return new InstructionInfo(modes[addressingMode])
+    return new InstructionInfo(name, addressingMode, modes[addressingMode])
   }
 
   /**
    * Creates a new `InstructionInfo` object. Do not use this constructor
    * directly, instead use the static `InstructionInfo.get`.
+   * @param {string} name Name of the instruction.
    * @param {object} definition Instruction addressing mode definition for the
    *   information model.
    * @see InstructionInfo.get
    */
-  constructor (definition) {
+  constructor (name, addressingMode, definition) {
+    this._addressingMode = addressingMode
     this._definition = definition
+    this._name = name
+  }
+
+  /**
+   * @return {string} The addressing mode for the instruction.
+   */
+  get addressingMode () {
+    return this._addressingMode
   }
 
   /**
@@ -131,6 +141,13 @@ class InstructionInfo {
    */
   get length () {
     return this._definition.bytes
+  }
+
+  /**
+   * @return {string} The name of the instruction.
+   */
+  get name () {
+    return this._name
   }
 
   /**

--- a/src/assembler/parser.js
+++ b/src/assembler/parser.js
@@ -101,6 +101,7 @@ function parse (source) {
         node.forEach(n => {
           n.line = line
           setNodeLine(line, n)
+          parsed.push(n)
         })
       } else {
         setNodeLine(line, node)

--- a/src/assembler/parser.js
+++ b/src/assembler/parser.js
@@ -7,22 +7,16 @@ const ParseNode = require('./ParseNode')
 class ParseError extends Error {
   /**
    * Creates a new parse error.
-   * @param {array} errors An array of errors that occurred during parsing.
+   * @param {Error} err The PEG parsing error.
+   * @param {object} line Information about the offending line.
+   * @param {number} line.lineNumber The line number in the source where the
+   *   error occurred.
+   * @param {string} line.assembly The assembly source that caused the error.
    */
-  constructor (errors) {
-    super('Failed to parse.')
-    this._errors = Object.freeze(errors)
-  }
-
-  /**
-   * An array of objects containing an error and the line on which it occurred.
-   * @type {array}
-   */
-  get errors () {
-    return this._errors
+  constructor (err, { lineNumber, assembly }) {
+    super(`Parse Error, line ${lineNumber} near "${assembly}": ${err}`)
   }
 }
-
 module.exports.ParseError = ParseError
 
 /**
@@ -61,7 +55,6 @@ class ParseLine {
     return this._data.assembly
   }
 }
-
 module.exports.ParseLine = ParseLine
 
 /**
@@ -108,12 +101,8 @@ function parse (source) {
         parsed.push(node)
       }
     } catch (err) {
-      parseErrors.push({ line, err })
+      throw new ParseError(err, line)
     }
-  }
-
-  if (parseErrors.length > 0) {
-    throw new ParseError(parseErrors)
   }
 
   return ParseNode.statementList(parsed)

--- a/src/assembler/parser.test.js
+++ b/src/assembler/parser.test.js
@@ -1,66 +1,128 @@
 const { test, expect } = require('@jest/globals')
+const ParseNode = require('./ParseNode')
 const { parse, ParseError } = require('./parser')
 
-/*
-test('parses valid 6502 macro assembly', () => {
-  const result = parse(`
-    lda #22 ; comments be gone, yo
-    ; this should be stripped!
-    @loop: ldx $20
+
+test('parses valid 6502 assembly', () => {
+  const parseNode = parse(`
+  @loop: dex
+    bne @loop
+    rts
   `)
-  expect(result).toEqual([
-    {
-      original: '    lda #22 ; comments be gone, yo\n',
-      lineNumber: 2,
-      assembly: 'lda #22',
-      node: {
-        type: 'instruction',
-        name: 'lda',
-        mode: {
-          type: 'addressingMode',
-          mode: 'expression',
-          value: {
-            type: 'immediate',
-            number: {
-              type: 'number',
-              base: 10,
-              value: 22
-            }
-          }
-        }
-      }
-    },
-    {
-      original: '    @loop: ldx $20\n',
-      lineNumber: 4,
-      assembly: '@loop: ldx $20',
-      node: {
-        type: 'label',
-        name: 'loop',
-        local: true
-      }
-    },
-    {
-      original: '    @loop: ldx $20\n',
-      lineNumber: 4,
-      assembly: '@loop: ldx $20',
-      node: {
-        type: 'instruction',
-        name: 'ldx',
-        mode: {
-          type: 'addressingMode',
-          mode: 'expression',
-          value: {
-            type: 'number',
-            base: 16,
-            value: 32
-          }
-        }
-      }
-    }
-  ])
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(4)
+
+  const [label, dex, bne, rts] = parseNode.children
+
+  expect(label).toBeInstanceOf(ParseNode)
+  expect(label.type).toEqual('localLabel')
+  expect(label.data.name).toEqual('loop')
+
+  expect(dex).toBeInstanceOf(ParseNode)
+  expect(dex.type).toEqual('instruction')
+  expect(dex.data.name).toEqual('dex')
+
+  expect(bne).toBeInstanceOf(ParseNode)
+  expect(bne.type).toEqual('instruction')
+  expect(bne.data.name).toEqual('bne')
+
+  expect(rts).toBeInstanceOf(ParseNode)
+  expect(rts.type).toEqual('instruction')
+  expect(rts.data.name).toEqual('rts')
 })
-*/
+
+test('parses commands', () => {
+  const parseNode = parse(`.org $C000`)
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(1)
+
+  const [org] = parseNode.children
+  expect(org).toBeInstanceOf(ParseNode)
+  expect(org.type).toEqual('command')
+  expect(org.data.name).toEqual('org')
+})
+
+test('correctly parses inline labels', () => {
+  const parseNode = parse(`do_nothing: rts`)
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(2)
+
+  const [label, rts] = parseNode.children
+
+  expect(label).toBeInstanceOf(ParseNode)
+  expect(label.type).toEqual('label')
+  expect(label.data.name).toEqual('do_nothing')
+
+  expect(rts).toBeInstanceOf(ParseNode)
+  expect(rts.type).toEqual('instruction')
+  expect(rts.data.name).toEqual('rts')
+})
+
+test('correctly parses isolated labels', () => {
+  const parseNode = parse(`
+  do_nothing:
+    rts
+  `)
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(2)
+
+  const [label, rts] = parseNode.children
+
+  expect(label).toBeInstanceOf(ParseNode)
+  expect(label.type).toEqual('label')
+  expect(label.data.name).toEqual('do_nothing')
+
+  expect(rts).toBeInstanceOf(ParseNode)
+  expect(rts.type).toEqual('instruction')
+  expect(rts.data.name).toEqual('rts')
+})
+
+test('correctly parses inline local labels', () => {
+  const parseNode = parse(`@loop: rts`)
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(2)
+
+  const [label, rts] = parseNode.children
+
+  expect(label).toBeInstanceOf(ParseNode)
+  expect(label.type).toEqual('localLabel')
+  expect(label.data.name).toEqual('loop')
+
+  expect(rts).toBeInstanceOf(ParseNode)
+  expect(rts.type).toEqual('instruction')
+  expect(rts.data.name).toEqual('rts')
+})
+
+test('correctly parses isolated local labels', () => {
+  const parseNode = parse(`
+  @loop:
+    rts
+  `)
+
+  expect(parseNode).toBeInstanceOf(ParseNode)
+  expect(parseNode.type).toEqual('statementList')
+  expect(parseNode.children.length).toEqual(2)
+
+  const [label, rts] = parseNode.children
+
+  expect(label).toBeInstanceOf(ParseNode)
+  expect(label.type).toEqual('localLabel')
+  expect(label.data.name).toEqual('loop')
+
+  expect(rts).toBeInstanceOf(ParseNode)
+  expect(rts.type).toEqual('instruction')
+  expect(rts.data.name).toEqual('rts')
+})
 
 test('on parse errors throws `ParseError`', () => {
   expect(() => parse('invalid @U(_))U(_)@UH')).toThrow(ParseError)


### PR DESCRIPTION
* Fixed an issue where the parser was eating `ParseNode`s for inline labels
* Improved the error reporting from both the assembler and parser
* Fleshed out LIR representation models for the assembler
* Added more testing for the assembler and parser